### PR TITLE
UA variable and example fix

### DIFF
--- a/categorizr-redirect.php
+++ b/categorizr-redirect.php
@@ -35,7 +35,11 @@ $catergorize_tvs_as_desktops     = FALSE;  //If TRUE, smartTVs will be categoriz
 $category = 'category';
 
 //Set User Agent = $ua
-$ua = $_SERVER['HTTP_USER_AGENT'];
+if(isset($_SERVER['HTTP_USER_AGENT'])) {
+	$ua = $_SERVER['HTTP_USER_AGENT'];	
+} else {
+	$ua = '';
+}
 
 // Check if session has already started, otherwise E_NOTICE is thrown
 if (session_id() == "")

--- a/categorizr.php
+++ b/categorizr.php
@@ -35,7 +35,11 @@ $catergorize_tvs_as_desktops     = FALSE;  //If TRUE, smartTVs will be categoriz
 $category = 'category';
 
 //Set User Agent = $ua
-$ua = $_SERVER['HTTP_USER_AGENT'];
+if(isset($_SERVER['HTTP_USER_AGENT'])) {
+	$ua = $_SERVER['HTTP_USER_AGENT'];	
+} else {
+	$ua = '';
+}
 
 // Check if session has already started, otherwise E_NOTICE is thrown
 if (session_id() == "")

--- a/example.php
+++ b/example.php
@@ -1,4 +1,4 @@
-<?php include("categorizr/categorizr.php");?>
+<?php include("categorizr.php");?>
 <!DOCTYPE html>
 <head>
 <meta charset="utf-8" />


### PR DESCRIPTION
Discard the previous pull request. I forgot I branched from it.

These two changes in three files fix some issues I have found while using categorizr.
1. The example didn't work straight out of the "box" when I tested it.
2. Sometimes, I don't know by what reason the server doesn't receive a UA string by the client. 

Found the last one trough my commercial project development where a couple of clients were complaining about a lot of errors in their logs generated by the categorizr library. Thank you that you made it mobile-first, otherwise the problem would have been much bigger. That is why I switched to categorizr from mdetect after all. Keep up the good work!
